### PR TITLE
Fix cross-context entity tracking

### DIFF
--- a/CloudSync.Core/Services/SyncService.cs
+++ b/CloudSync.Core/Services/SyncService.cs
@@ -17,15 +17,19 @@ public class SyncService : ISyncService
 
     public async Task<bool> SyncDataAsync(string data)
     {
-        var entity = new DataEntity { Data = data };
+        // Create separate entity instances for each context. EF Core does not
+        // allow the same entity instance to be tracked by multiple DbContext
+        // instances simultaneously.
+        var azureEntity = new DataEntity { Data = data };
+        var awsEntity = new DataEntity { Data = data };
 
         await using var azureTransaction = await _azureContext.Database.BeginTransactionAsync();
         await using var awsTransaction = await _awsContext.Database.BeginTransactionAsync();
 
         try
         {
-            await _azureContext.DataEntities.AddAsync(entity);
-            await _awsContext.DataEntities.AddAsync(entity);
+            await _azureContext.DataEntities.AddAsync(azureEntity);
+            await _awsContext.DataEntities.AddAsync(awsEntity);
 
             await _azureContext.SaveChangesAsync();
             await _awsContext.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- avoid sharing entity instance across DbContexts in SyncService

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build CloudSyncSolution.sln -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_684370cfe32c8329a081ca655856090c